### PR TITLE
Support macos-12 packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,16 +6,19 @@ const github = require("@actions/github");
 const toolCache = require("@actions/tool-cache");
 
 function findArchive({version, nodePlatform}) {
-    const wabtPlatform = nodePlatformToWabtPlatform(nodePlatform);
+    const wabtPlatform = nodePlatformToWabtPlatform(version, nodePlatform);
     const directoryName = `wabt-${version}`;
 
     return [directoryName, `https://github.com/WebAssembly/wabt/releases/download/${version}/${directoryName}-${wabtPlatform}.tar.gz`]
 }
 
-function nodePlatformToWabtPlatform(nodePlatform) {
+function nodePlatformToWabtPlatform(version, nodePlatform) {
     switch (nodePlatform) {
         case "darwin":
-            return "macos-12";
+            versionPartsStr = version.split('.');
+            versionParts = versionPartsStr.map(function(item) {return Number(item);})
+            has12Extension = (versionParts.length === 3) && (versionParts[2] >= 30);
+            return has12Extension ? "macos-12" : "macos";
         case "linux":
             return "ubuntu";
         case "win32":

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function findArchive({version, nodePlatform}) {
 function nodePlatformToWabtPlatform(nodePlatform) {
     switch (nodePlatform) {
         case "darwin":
-            return "macos";
+            return "macos-12";
         case "linux":
             return "ubuntu";
         case "win32":


### PR DESCRIPTION
Hi,

As you can see on the https://github.com/WebAssembly/wabt/releases/ page, the macos packages starting with version 30 have a -12 in the name. Currently when looking for package `https://github.com/WebAssembly/wabt/releases/download/1.0.31/wabt-1.0.31-macos-12.tar.gz`, the code will generate this path instead, leading to a 404: `https://github.com/WebAssembly/wabt/releases/download/1.0.31/wabt-1.0.31-macos.tar.gz`. These changes should handle both syncing older and newer packages.

Thanks,

Reuben

